### PR TITLE
Fix ruff lint step failures

### DIFF
--- a/src/ia_writer_templates/main.py
+++ b/src/ia_writer_templates/main.py
@@ -16,11 +16,10 @@ from pathlib import Path
 from typing import Any
 
 
-# Constants for directory paths
-# These paths are relative to the project root
-FRAGMENTS_DIR = Path("src/fragments")
-TEMPLATES_DIR = Path("templates")
-OUTPUT_DIR = Path("dist/templates")
+# Constants for directory paths relative to the project root
+FRAGMENTS_DIR_RELATIVE = Path("src/fragments")
+TEMPLATES_DIR_RELATIVE = Path("templates")
+OUTPUT_DIR_RELATIVE = Path("dist/templates")
 
 
 def get_project_root() -> Path:
@@ -36,6 +35,13 @@ def get_project_root() -> Path:
             return parent
     # Fallback to current working directory
     return Path.cwd()
+
+
+# Resolved absolute paths used throughout the module
+PROJECT_ROOT = get_project_root()
+FRAGMENTS_DIR = PROJECT_ROOT / FRAGMENTS_DIR_RELATIVE
+TEMPLATES_DIR = PROJECT_ROOT / TEMPLATES_DIR_RELATIVE
+OUTPUT_DIR = PROJECT_ROOT / OUTPUT_DIR_RELATIVE
 
 
 def slugify(name: str) -> str:
@@ -271,7 +277,8 @@ def build_bundle(template_dir: Path) -> None:
                 encoding="utf-8",
             )
         except FileNotFoundError:
-            # Skip missing fragments (e.g., GitHub template only has document.html)
+            # Skip missing fragments.
+            # GitHub template only requires document.html.
             if fragment_name == "document.html":
                 # document.html is required
                 raise
@@ -323,13 +330,6 @@ def main() -> None:
         RuntimeError: If no templates directory exists or no templates found.
         SystemExit: On any build errors.
     """
-    # Get the project root and set up paths
-    root = get_project_root()
-    global FRAGMENTS_DIR, TEMPLATES_DIR, OUTPUT_DIR
-    FRAGMENTS_DIR = root / FRAGMENTS_DIR
-    TEMPLATES_DIR = root / TEMPLATES_DIR
-    OUTPUT_DIR = root / OUTPUT_DIR
-
     # Clean and recreate output directory
     if OUTPUT_DIR.parent.exists():
         shutil.rmtree(OUTPUT_DIR.parent)

--- a/tests/test_github_download.py
+++ b/tests/test_github_download.py
@@ -1,12 +1,11 @@
 """Test GitHub template fixture availability."""
 
+import shutil
 import subprocess
 from pathlib import Path
 
-import pytest
 
-
-def test_github_template_fixture_exists():
+def test_github_template_fixture_exists() -> None:
     """Test that GitHub template exists in fixtures directory."""
     fixtures_dir = Path(__file__).parent / "fixtures"
     template_path = fixtures_dir / "GitHub.iatemplate" / "Contents"
@@ -36,14 +35,19 @@ def test_github_template_fixture_exists():
     print(f"GitHub template fixture found at: {template_path}")
 
 
-def test_download_github_template_if_missing(tmp_path):
-    """Test that we can download the GitHub template from repository if fixture is missing."""
+def test_download_github_template_if_missing(tmp_path: Path) -> None:
+    """Download the GitHub template from the upstream repository when absent."""
     repo_url = "https://github.com/iainc/iA-Writer-Templates.git"
     repo_dir = tmp_path / "iA-Writer-Templates"
 
+    git_executable = shutil.which("git")
+    if git_executable is None:
+        msg = "Git executable not found on PATH"
+        raise RuntimeError(msg)
+
     # Clone from GitHub
-    result = subprocess.run(
-        ["git", "clone", "--depth", "1", repo_url, str(repo_dir)],
+    subprocess.run(
+        [git_executable, "clone", "--depth", "1", repo_url, str(repo_dir)],
         check=True,
         capture_output=True,
         text=True,
@@ -75,4 +79,4 @@ if __name__ == "__main__":
     import tempfile
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        test_download_github_template(Path(tmpdir))
+        test_download_github_template_if_missing(Path(tmpdir))


### PR DESCRIPTION
## Summary
- resolve project directories at import time in `main.py` to avoid global reassignment and satisfy linting
- tighten GitHub download test helpers with annotations and safer git discovery for ruff compatibility
- clean up integration tests with shared environment typing, pathlib usage, and top-level imports required by the lint rules

## Testing
- uv run ruff format src tests
- uv run ruff check
- PYTHONPATH=src uv run pytest tests/ *(fails: network access to clone upstream GitHub repository is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d05a89d74c8320bcaa1db47e383cbd